### PR TITLE
Solve problem 2020/25

### DIFF
--- a/2020/25/approach.md
+++ b/2020/25/approach.md
@@ -1,0 +1,27 @@
+### Thoughts:
+
+First of all I take an example from the problem:
+Input:
+card pub key: 5764801
+door pub key: 17807724
+
+Output:
+encryption key (private key): 14897079
+
+The input has confused me because I expected that the subject number will be provided there. 
+So, I decided that I need to generate the subject number on my own. Code became very complex I decided that it was the wrong direction.
+I reviewed the problem statement one more time and explored that there were additional data that can help me:
+
+Subject number: 7
+Card loop size: 8
+Door loop size: 11
+
+So, I've taken the example and write the first test. 
+Also, I tried to get loop count of private key (14897079) and explored that it's 88 = 8 * 11 (that seems like card_loop_size * door_loop_size)
+
+### Approach
+
+1. Write for loop with transforming the subject number till find the card loop size
+2. Take a card loop size and transform door pub key card loop size times 
+(OR we can get loop size of door as well and than transform subject card_loop_size * door_loop_size times BUT it will be much much slower)
+3. Profit!

--- a/2020/25/approach.md
+++ b/2020/25/approach.md
@@ -9,7 +9,7 @@ Output:
 encryption key (private key): 14897079
 
 The input has confused me because I expected that the subject number will be provided there. 
-So, I decided that I need to generate the subject number on my own. Code became very complex I decided that it was the wrong direction.
+So, I decided that I need to generate the subject number on my own. The first version of code became very complex I decided that it was the wrong direction.
 I reviewed the problem statement one more time and explored that there were additional data that can help me:
 
 Subject number: 7

--- a/2020/25/golang/breaker/combo-breaker.go
+++ b/2020/25/golang/breaker/combo-breaker.go
@@ -1,0 +1,47 @@
+package breaker;
+
+import (
+	"fmt"
+	"errors"
+)
+
+type ComboBreaker struct {
+	MOD, MAX_LOOP_COUNT int
+}
+
+func (breaker ComboBreaker) GetLoopSize(subject int, pubKey int) (int, error) {
+	generated_pub_key := subject
+	for i := 1; i < breaker.MAX_LOOP_COUNT; i++ {
+		generated_pub_key = (generated_pub_key * subject) % breaker.MOD
+		if generated_pub_key == pubKey {
+			return i + 1, nil
+		}
+	}
+	return 0, errors.New(fmt.Sprintf("Could not find loop size. subject=%d, pub_key=%d", subject, pubKey))
+
+}
+
+func (breaker ComboBreaker) GetPrivateKey(loopSize int, pubKey int) int {
+	private_key := 1
+
+	for i := 0; i < loopSize; i++ {
+		private_key = (private_key * pubKey) % breaker.MOD
+	}
+	
+	return private_key
+}
+
+func (breaker ComboBreaker) Decrypt(subject int, cardPubKey int, doorPubKey int) (int, error) {
+
+	var cardLoopSize, e = breaker.GetLoopSize(subject, cardPubKey)
+
+	fmt.Println("Card loop size: ", cardLoopSize)
+
+	if e != nil {
+		return 0, e
+	}
+
+	privateKey := breaker.GetPrivateKey(cardLoopSize, doorPubKey)
+
+	return privateKey, nil;
+}

--- a/2020/25/golang/breaker_test.go
+++ b/2020/25/golang/breaker_test.go
@@ -1,0 +1,44 @@
+package main 
+
+import (
+	"./breaker"
+	"testing"
+)
+
+func TestShouldPassWithExampleInput(t *testing.T){
+	breaker := breaker.ComboBreaker{MOD: 20201227, MAX_LOOP_COUNT: 20201227}
+	
+	var privateKey, _ = breaker.Decrypt(7, 5764801, 17807724)
+
+	if privateKey == 14897079 {
+		t.Log("PASSED breaker.Decrypt(7, 5764801, 17807724)")
+	} else {
+		t.Errorf("FAILED breaker.Decrypt(7, 5764801, 17807724), expected value %d", 14897079)
+	}
+}
+
+func TestShouldPassWithGivenInput(t *testing.T){
+	breaker := breaker.ComboBreaker{MOD: 20201227, MAX_LOOP_COUNT: 20201227}
+	
+	door_private_key, _ := breaker.Decrypt(7, 2069194, 16426071)
+	card_private_key, _ := breaker.Decrypt(7, 16426071, 2069194)
+
+	if door_private_key == card_private_key {
+		t.Log("PASSED breaker.Decrypt(7, 2069194, 16426071)")
+	} else {
+		t.Errorf("FAILED breaker.Decrypt(7, 2069194, 16426071), expected value %d", 14897079)
+	}
+}
+
+
+func TestShouldFailWithBadInput(t *testing.T){
+	breaker := breaker.ComboBreaker{MOD: 20201227, MAX_LOOP_COUNT: 20201227}
+	
+	_, e := breaker.Decrypt(10, 0, 0)
+
+	if e != nil {
+		t.Logf("PASSED with captured error %d", e)
+	} else {
+		t.Errorf("FAILED with no error")
+	}
+}

--- a/2020/25/golang/breaker_test.go
+++ b/2020/25/golang/breaker_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestShouldPassWithExampleInput(t *testing.T){
+func TestShouldPassWithExampleFromPlatformInput(t *testing.T){
 	breaker := breaker.ComboBreaker{MOD: 20201227, MAX_LOOP_COUNT: 20201227}
 	
 	var privateKey, _ = breaker.Decrypt(7, 5764801, 17807724)
@@ -17,7 +17,7 @@ func TestShouldPassWithExampleInput(t *testing.T){
 	}
 }
 
-func TestShouldPassWithGivenInput(t *testing.T){
+func TestShouldPassWithGivenByPlatformInput(t *testing.T){
 	breaker := breaker.ComboBreaker{MOD: 20201227, MAX_LOOP_COUNT: 20201227}
 	
 	door_private_key, _ := breaker.Decrypt(7, 2069194, 16426071)

--- a/2020/25/golang/main.go
+++ b/2020/25/golang/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"./breaker"
+	"fmt"
+)
+
+func main() {
+	breaker := breaker.ComboBreaker{MOD :20201227, MAX_LOOP_COUNT: 20201227}
+	
+	var privateKey, _ = breaker.Decrypt(7, 5764801, 17807724)
+
+	fmt.Println(privateKey)
+
+}

--- a/2020/25/python/breaker_test.py
+++ b/2020/25/python/breaker_test.py
@@ -1,0 +1,31 @@
+import unittest
+from combo_breaker import ComboBreaker
+
+
+class ComboBreakerTests(unittest.TestCase):
+
+    def test_example_input(self):
+        breaker = ComboBreaker()
+
+        private_key = breaker.decrypt(7, 5764801, 17807724)
+
+        self.assertEqual(private_key, 14897079)
+
+    def test_given_input(self):
+        breaker = ComboBreaker()
+
+        door_private_key = breaker.decrypt(7, 2069194, 16426071)
+        card_private_key = breaker.decrypt(7, 16426071, 2069194)
+
+        self.assertEqual(door_private_key, 11576351)
+        self.assertEqual(door_private_key, card_private_key)
+
+    @unittest.expectedFailure
+    def test_should_fail_with_incorrect_pubkeys(self):
+        breaker = ComboBreaker()
+
+        private_key = breaker.decrypt(10, 0, 0)
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/2020/25/python/breaker_test.py
+++ b/2020/25/python/breaker_test.py
@@ -4,14 +4,14 @@ from combo_breaker import ComboBreaker
 
 class ComboBreakerTests(unittest.TestCase):
 
-    def test_example_input(self):
+    def test_example_from_platform_input(self):
         breaker = ComboBreaker()
 
         private_key = breaker.decrypt(7, 5764801, 17807724)
 
         self.assertEqual(private_key, 14897079)
 
-    def test_given_input(self):
+    def test_given_by_platform_input(self):
         breaker = ComboBreaker()
 
         door_private_key = breaker.decrypt(7, 2069194, 16426071)

--- a/2020/25/python/combo_breaker.py
+++ b/2020/25/python/combo_breaker.py
@@ -1,0 +1,37 @@
+class ComboBreaker:
+    
+    def __init__(self, max_loop_count = 20201227, mod = 20201227):
+        self.__max_loop_count = max_loop_count
+        self.__mod = mod
+
+    def decrypt(self, subject, card_pub_key, door_pub_key):
+
+        try:
+            card_loop_size = self.__get_loop_size(subject, card_pub_key)
+
+            print(f'Success to get loop size! card_loop_size={card_loop_size}', )
+        
+            private_key = self.__get_private_key(card_loop_size, door_pub_key)
+
+            return private_key
+        except Exception:
+            print(f'Error! Check the parameters: subject={subject}, card_pub_key={card_pub_key}, door_pub_key={door_pub_key}')
+            raise;
+
+    def __get_private_key(self, loop_size, pub_key):
+        private_key = 1
+
+        for _ in range(loop_size):
+            private_key = (private_key * pub_key) % self.__mod
+        
+        return private_key
+
+    def __get_loop_size(self, subject, pub_key):
+        generated_pub_key = subject
+
+        for loopSize in range(1, self.__max_loop_count):
+            generated_pub_key = (generated_pub_key * subject) % self.__mod
+            if generated_pub_key == pub_key: 
+                return loopSize + 1
+
+        raise Exception(f'Could not find loop size. subject={subject}, pub_key={pub_key}')


### PR DESCRIPTION
# Problem:
https://adventofcode.com/2020/day/25

### Thoughts:

First of all, I take an example from the problem:
Input:
card pub key: 5764801
door pub key: 17807724

Output:
encryption key (private key): 14897079

The input has confused me because I expected that the subject number will be provided there. 
So, I decided that I need to generate the subject number on my own. The first version of code started to become very complex I decided that it was the wrong direction.
I reviewed the problem statement one more time and explored that there were additional data that can help me:

Subject number: 7
Card loop size: 8
Door loop size: 11

So, I've taken the example and write the first test. 
Also, I tried to get loop count of private key (14897079) and explored that it's 88 = 8 * 11 (that seems like card_loop_size * door_loop_size)

### Approach

1. Write for loop with transforming the subject number till find the card loop size
2. Take a card loop size and transform door pub key card loop size times 
(OR we can get loop size of door as well and than transform subject card_loop_size * door_loop_size times BUT it will be much much slower)
3. Profit!